### PR TITLE
Include built-in standard E6-E96 resistor values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ Constraint arguments specify requirements that a valid solution must satisfy. Mo
 
 The database file is a list of resistor values which are available for use. This is an ASCII text file with one
 resistor value per line. Values may use "k" or "M" suffixes, for example "1M" or "4.7k".
+
+# Standard values
+
+Instead of (or in addition to) a database file, `vdcalc` may use standard E6-96 resistor values. These include
+values from single digit ohms through megaohms, e.g. the E6 set includes 2.2, 2.2k, 22k, 220k and 2M values.
+These sets are available via the following command-line options:
+
+`--e6`: include the E6 standard resistor values (20% tolerance)
+`--e12`: include the E12 standard resistor values (10% tolerance)
+`--e24`: include the E24 standard resistor values (5% tolerance)
+`--e48`: include the E48 standard resistor values (2% tolerance)
+`--e96`: include the E96 standard resistor values (1% tolerance)

--- a/main.cpp
+++ b/main.cpp
@@ -28,7 +28,7 @@
 ***********************************************************************************************************************/
 
 #include <stdio.h>
-#include <vector>
+#include <set>
 #include <stdint.h>
 #include <float.h>
 #include <math.h>
@@ -40,10 +40,46 @@ void ShowHelp();
 
 void PrintResistance(const char* name, float value);
 float ParseResistance(const char* str);
+void AddStandardValues(set<float> *db, const float *values, int n);
+
+// Standard E* values.
+const float e6[] = {
+	1.0, 1.5, 2.2, 3.3, 4.7, 6.8
+};
+const float e12[] = {
+	1.0, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2
+ };
+const float e24[] = {
+	1.0, 1.1, 1.2, 1.3, 1.5, 1.6, 1.8, 2.0, 2.2, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.3, 4.7, 5.1, 5.6, 6.2, 6.8, 7.5, 8.2, 9.1
+};
+const float e48[] = {
+	1.00, 1.05, 1.10, 1.15, 1.21, 1.27, 1.33, 1.40, 1.47, 1.54, 1.62, 1.69, 1.78, 1.87, 1.96, 2.05, 2.15, 2.26, 2.37, 2.49,
+	2.61, 2.74, 2.87, 3.01, 3.16, 3.32, 3.48, 3.65, 3.83, 4.02, 4.22, 4.42, 4.64, 4.87, 5.11, 5.36, 5.62, 5.90, 6.19, 6.49,
+	6.81, 7.15, 7.50, 7.87, 8.25, 8.66, 9.09, 9.53
+ };
+const float e96[] = {
+	1.00, 1.02, 1.05, 1.07, 1.10, 1.13, 1.15, 1.18, 1.21, 1.24, 1.27, 1.30, 1.33, 1.37, 1.40, 1.43, 1.47, 1.50, 1.54, 1.58,
+	1.62, 1.65, 1.69, 1.74, 1.78, 1.82, 1.87, 1.91, 1.96, 2.00, 2.05, 2.10, 2.15, 2.21, 2.26, 2.32, 2.37, 2.43, 2.49, 2.55,
+	2.61, 2.67, 2.74, 2.80, 2.87, 2.94, 3.01, 3.09, 3.16, 3.24, 3.32, 3.40, 3.48, 3.57, 3.65, 3.74, 3.83, 3.92, 4.02, 4.12,
+	4.22, 4.32, 4.42, 4.53, 4.64, 4.75, 4.87, 4.99, 5.11, 5.23, 5.36, 5.49, 5.62, 5.76, 5.90, 6.04, 6.19, 6.34, 6.49, 6.65,
+	6.81, 6.98, 7.15, 7.32, 7.50, 7.68, 7.87, 8.06, 8.25, 8.45, 8.66, 8.87, 9.09, 9.31, 9.53, 9.76
+};
+
+void AddStandardValues(set<float> *db, const float *values, int n)
+{
+	for (int i = 0; i < sizeof(e12) / sizeof(*e12); i++)
+	{
+		db->emplace(values[i]);
+		db->emplace(values[i] * 1000);
+		db->emplace(values[i] * 10000);
+		db->emplace(values[i] * 100000);
+		db->emplace(values[i] * 1000000);
+	}
+}
 
 int main(int argc, char* argv[])
 {
-	vector<float> db;
+	set<float> db;
 	string dbFile;
 
 	float minSum = -1;
@@ -67,8 +103,12 @@ int main(int argc, char* argv[])
 	for(int i=1; i<argc; i++)
 	{
 		string s(argv[i]);
-
-		if(s == "--database")
+		if (s == "--e6") AddStandardValues(&db, e6, sizeof(e6) / sizeof(*e6));
+		else if (s == "--e12") AddStandardValues(&db, e12, sizeof(e12) / sizeof(*e12));
+		else if (s == "--e24") AddStandardValues(&db, e24, sizeof(e24) / sizeof(*e24));
+		else if (s == "--e48") AddStandardValues(&db, e48, sizeof(e48) / sizeof(*e48));
+		else if (s == "--e96") AddStandardValues(&db, e96, sizeof(e96) / sizeof(*e96));
+		else if(s == "--database")
 		{
 			if(i+1 < argc)
 			{
@@ -246,23 +286,29 @@ int main(int argc, char* argv[])
 	//Load database file
 	if(dbFile.empty())
 	{
-		fprintf(stderr, "No component database file specified, use --database file.txt\n");
-		return 1;
+		if (db.size() == 0)
+		{
+			fprintf(stderr, "No component database file specified, use --database file.txt\n");
+			return 1;
+		}
 	}
-	FILE* fp = fopen(dbFile.c_str(), "r");
-	if(!fp)
+	else
 	{
-		fprintf(stderr, "Failed to open database file\n");
-		return 1;
+		FILE* fp = fopen(dbFile.c_str(), "r");
+		if(!fp)
+		{
+			fprintf(stderr, "Failed to open database file\n");
+			return 1;
+		}
+		while(!feof(fp))
+		{
+			char line[128] = {0};
+			if(nullptr == fgets(line, sizeof(line), fp))
+				break;
+			db.emplace(ParseResistance(line));
+		}
+		fclose(fp);
 	}
-	while(!feof(fp))
-	{
-		char line[128] = {0};
-		if(nullptr == fgets(line, sizeof(line), fp))
-			break;
-		db.push_back(ParseResistance(line));
-	}
-	fclose(fp);
 
 	//Iterate over all possible values for R1 (upper resistor)
 	float closestR1 = 0;


### PR DESCRIPTION
These may be used instead or, or in addition to the `--database` file
via `--e6` / `--e12` / `--e24` / `--e48` / `--e96` command-line options.

Changes the `db` datatype from `vector` to `set` to avoid duplicates between
the standard values and the database file.